### PR TITLE
feat: adds support to define the port and the host to start the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,17 @@ django-ai-boost
 # Or specify settings directly
 django-ai-boost --settings myproject.settings
 
-# Run with SSE transport (default is stdio)
+# Run with SSE transport (default is stdio, which doesn't use network ports)
 django-ai-boost --settings myproject.settings --transport sse
+
+# Run with SSE transport on a custom port (default port is 8000)
+django-ai-boost --settings myproject.settings --transport sse --port 3000
+
+# Run with SSE transport on custom host and port
+django-ai-boost --settings myproject.settings --transport sse --host 0.0.0.0 --port 8080
 ```
+
+**Note:** The stdio transport (default) communicates via standard input/output and does not use network ports. The `--port` and `--host` options only apply when using `--transport sse`.
 
 ## AI Tools Setup
 
@@ -272,11 +280,17 @@ Add to your Zed MCP configuration (`~/.config/zed/mcp.json`):
 For any MCP-compatible client, you can run the server manually:
 
 ```bash
-# Standard I/O transport (default)
+# Standard I/O transport (default, no network port)
 django-ai-boost --settings myproject.settings
 
-# Server-Sent Events transport
+# Server-Sent Events transport (default: 127.0.0.1:8000)
 django-ai-boost --settings myproject.settings --transport sse
+
+# SSE transport with custom port
+django-ai-boost --settings myproject.settings --transport sse --port 3000
+
+# SSE transport with custom host and port
+django-ai-boost --settings myproject.settings --transport sse --host 0.0.0.0 --port 8080
 ```
 
 ## Available Tools and Prompts
@@ -464,6 +478,17 @@ Or in your MCP client configuration:
 ### Database Connection Issues
 
 Ensure your Django database is properly configured and accessible. The MCP server needs the same database access as your Django application.
+
+### Port Already in Use (SSE Transport)
+
+If you see an error like "Address already in use" when using SSE transport, the default port 8000 is likely occupied by another service (such as your Django development server). Use a different port:
+
+```bash
+# Use a different port for the MCP server
+django-ai-boost --settings myproject.settings --transport sse --port 8001
+```
+
+**Note:** The stdio transport (default) does not use network ports and will not have this issue.
 
 ## Requirements
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-ai-boost"
-version = "0.3.1"
+version = "0.4.0"
 description = "A Model Context Protocol (MCP) server for Django applications, inspired by Laravel Boost"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/vintasoftware/django-ai-boost",
     "source": "github"
   },
-  "version": "0.3.1",
+  "version": "0.4.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "django-ai-boost",
-      "version": "0.3.1",
+      "version": "0.4.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/django_ai_boost/__init__.py
+++ b/src/django_ai_boost/__init__.py
@@ -17,7 +17,23 @@ def main() -> None:
         default="stdio",
         help="Transport type (default: stdio)",
     )
+    parser.add_argument(
+        "--host",
+        default="127.0.0.1",
+        help="Host to bind to for SSE transport (default: 127.0.0.1)",
+    )
+    parser.add_argument(
+        "--port",
+        type=int,
+        default=8000,
+        help="Port to bind to for SSE transport (default: 8000)",
+    )
 
     args = parser.parse_args()
 
-    run_server(settings_module=args.settings, transport=args.transport)
+    run_server(
+        settings_module=args.settings,
+        transport=args.transport,
+        host=args.host,
+        port=args.port,
+    )

--- a/src/django_ai_boost/server_fastmcp.py
+++ b/src/django_ai_boost/server_fastmcp.py
@@ -574,19 +574,29 @@ Please provide clear, actionable information with direct links to the official d
     return prompt
 
 
-def run_server(settings_module: str | None = None, transport: str = "stdio"):
+def run_server(
+    settings_module: str | None = None,
+    transport: str = "stdio",
+    host: str = "127.0.0.1",
+    port: int = 8000,
+):
     """
     Run the Django MCP server.
 
     Args:
         settings_module: Django settings module path
         transport: Transport type (stdio or sse)
+        host: Host to bind to for SSE transport (default: 127.0.0.1)
+        port: Port to bind to for SSE transport (default: 8000)
     """
     # Initialize Django before starting the server
     initialize_django(settings_module)
 
     # Run the FastMCP server
-    mcp.run(transport=transport)
+    if transport == "sse":
+        mcp.run(transport=transport, host=host, port=port)
+    else:
+        mcp.run(transport=transport)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -271,7 +271,7 @@ wheels = [
 
 [[package]]
 name = "django-ai-boost"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "django" },


### PR DESCRIPTION
Update the `run_server` to support the `port` and `host` parameters.

Closes #3

## Summary by Sourcery

Add host and port parameters to the CLI and server for SSE transport, update documentation and bump version to 0.4.0

New Features:
- Allow specifying host and port for the MCP server via --host and --port when using SSE transport

Enhancements:
- Bump project version from 0.3.1 to 0.4.0

Documentation:
- Update README with examples, notes, and troubleshooting for custom host and port options