### PR TITLE
feat: add `read_recent_logs` tool; migrate tests to `pytest`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,22 +26,15 @@ Notes:
 - There is no separate compile/build step for this repository.
 - `ruff` is the formatter and linter source of truth.
 ## 4) Test Commands
-Primary test scripts used in this repo:
-- Run broad integration script:
-  - `uv run python test_server.py`
-- Run query-model tests:
-  - `uv run python test_query_model.py`
-- Run system-check tests:
-  - `uv run python test_run_check.py`
-- Run auth logic tests:
-  - `uv run python test_auth_logic.py`
-- Run prompt-related test script:
-  - `uv run python test_prompt.py`
-Pytest is also available:
-- Run all pytest tests:
+Pytest is the default test runner in this repo:
+- Run all tests:
   - `uv run pytest`
-- Verbose pytest:
+- Verbose mode:
   - `uv run pytest -v`
+- Focus on migrated MCP tool tests:
+  - `uv run pytest test_auth_logic.py test_prompt.py test_query_model.py test_read_recent_logs.py test_run_check.py`
+- Run broad integration coverage:
+  - `uv run pytest test_server.py`
 ### Running a single test (important)
 Use one of these patterns:
 - Single pytest file:
@@ -50,8 +43,6 @@ Use one of these patterns:
   - `uv run pytest test_auth_logic.py::test_validation_logic`
 - Filter by test name substring:
   - `uv run pytest -k validation_logic`
-- Single script-style test file (non-pytest harness):
-  - `uv run python test_query_model.py`
 ## 5) Running the Server Locally
 With env var:
 - `export DJANGO_SETTINGS_MODULE=myproject.settings`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,149 @@
+# AGENTS.md
+Guidance for coding agents working in `django-ai-boost`.
+## 1) Project Snapshot
+- Python package: `django-ai-boost`
+- Purpose: MCP server exposing read-only Django introspection tools
+- Runtime: Python `>=3.12`
+- Core deps: `django>=4.2`, `fastmcp>=2.14.5`
+- Package manager: `uv`
+- Entry point: `django-ai-boost` -> `django_ai_boost:main`
+- Main server module: `src/django_ai_boost/server_fastmcp.py`
+## 2) Environment Setup
+- Install runtime deps:
+  - `uv sync`
+- Install dev deps:
+  - `uv sync --dev`
+- Verify CLI:
+  - `uv run django-ai-boost --help`
+## 3) Build / Lint / Format Commands
+- Lint all Python files:
+  - `uv run ruff check .`
+- Auto-fix lint issues:
+  - `uv run ruff check --fix .`
+- Format code:
+  - `uv run ruff format .`
+Notes:
+- There is no separate compile/build step for this repository.
+- `ruff` is the formatter and linter source of truth.
+## 4) Test Commands
+Primary test scripts used in this repo:
+- Run broad integration script:
+  - `uv run python test_server.py`
+- Run query-model tests:
+  - `uv run python test_query_model.py`
+- Run system-check tests:
+  - `uv run python test_run_check.py`
+- Run auth logic tests:
+  - `uv run python test_auth_logic.py`
+- Run prompt-related test script:
+  - `uv run python test_prompt.py`
+Pytest is also available:
+- Run all pytest tests:
+  - `uv run pytest`
+- Verbose pytest:
+  - `uv run pytest -v`
+### Running a single test (important)
+Use one of these patterns:
+- Single pytest file:
+  - `uv run pytest test_auth_logic.py`
+- Single pytest test function:
+  - `uv run pytest test_auth_logic.py::test_validation_logic`
+- Filter by test name substring:
+  - `uv run pytest -k validation_logic`
+- Single script-style test file (non-pytest harness):
+  - `uv run python test_query_model.py`
+## 5) Running the Server Locally
+With env var:
+- `export DJANGO_SETTINGS_MODULE=myproject.settings`
+- `uv run django-ai-boost`
+With explicit settings arg:
+- `uv run django-ai-boost --settings myproject.settings`
+SSE transport:
+- `uv run django-ai-boost --settings myproject.settings --transport sse`
+- `uv run django-ai-boost --settings myproject.settings --transport sse --host 127.0.0.1 --port 8000`
+Fixture project quick run:
+- `export PYTHONPATH="${PYTHONPATH}:./fixtures/testproject"`
+- `uv run django-ai-boost --settings testproject.settings`
+## 6) Authentication and Safety Rules
+- Token env var: `DJANGO_MCP_AUTH_TOKEN`
+- Token precedence: env var > `--auth-token`
+- Auth tokens are only valid with `--transport sse`
+- `DEBUG=False` + SSE requires a token; startup should fail otherwise
+- `DEBUG=False` + stdio is allowed but intentionally unauthenticated
+- Never log or expose raw token values
+## 7) Code Style and Conventions
+### Formatting and imports
+- Follow `ruff check` + `ruff format` outputs exactly.
+- Keep imports grouped and ordered:
+  - stdlib
+  - third-party
+  - local package imports
+- Prefer explicit imports over wildcard imports.
+- Keep one import per line when practical.
+### Typing
+- Use Python 3.12+ type syntax:
+  - `str | None`, `list[str]`, `dict[str, Any]`
+- Keep type hints on all public functions.
+- Use `Any` only when unavoidable for dynamic payloads.
+- Return JSON-serializable structures from MCP tools.
+### Naming
+- Functions/variables: `snake_case`
+- Constants: `UPPER_CASE`
+- Modules: `snake_case`
+- Use clear action-oriented function names (`list_models`, `run_check`).
+### Async and Django ORM patterns
+- MCP tool handlers are `async def`.
+- Wrap blocking ORM/db work with `sync_to_async`.
+- Keep synchronous DB operations inside small inner helper functions.
+- Avoid blocking work directly in async handlers.
+### Error handling
+- For tool operations, prefer graceful error payloads:
+  - `{"error": "..."}`
+- Raise exceptions only for startup/config validation failures where aborting is correct.
+- Keep error messages actionable and specific.
+- Catch narrow exceptions when possible (`LookupError`, `NoReverseMatch`), then fallback to generic handling.
+### Tool behavior constraints
+- Preserve read-only behavior for introspection tools.
+- Do not add mutating database operations to current tools without explicit product direction.
+- Keep limits/guardrails (for example query limits) to prevent heavy operations.
+### Docs and comments
+- Keep docstrings for public tools and CLI-facing functions.
+- Add comments only for non-obvious logic.
+- Prefer concise, direct wording in docs and errors.
+## 8) File/Module-Specific Guidance
+- `src/django_ai_boost/__init__.py`
+  - CLI arg parsing and delegation to `run_server`.
+- `src/django_ai_boost/server_fastmcp.py`
+  - Django initialization
+  - auth validation
+  - tool and prompt registration
+  - server startup by transport
+- Keep tool registration centralized via `TOOLS` and `PROMPTS` lists.
+## 9) Cursor/Copilot Rule Files
+Checked in this repository:
+- `.cursor/rules/`: not found
+- `.cursorrules`: not found
+- `.github/copilot-instructions.md`: not found
+If these files are added later, treat them as higher-priority agent instructions and merge them into this guide.
+## 10) Practical Workflow for Agents
+1. Sync deps with `uv sync --dev`.
+2. Make focused code changes.
+3. Run `uv run ruff check .` and `uv run ruff format .`.
+4. Run the most relevant test file first (single-test pattern above).
+5. Run broader tests before finalizing.
+6. Ensure behavior remains read-only unless explicitly requested otherwise.
+
+## 11) Agent Guardrails
+
+- Make minimal, targeted changes and avoid unrelated refactors.
+- Do not change public behavior unless the task requires it.
+- Preserve CLI flags, tool names, and prompt names for compatibility.
+- Keep startup validation strict and fail early on misconfiguration.
+- Prefer adding tests near the behavior being changed.
+- When updating tests, keep fixtures deterministic and explicit.
+- Avoid introducing global state when function-local state is enough.
+- Keep return payload shapes stable for MCP clients.
+- Do not swallow exceptions silently; return actionable context.
+- Validate user-provided limits and keep hard caps in place.
+- Prefer clarity over cleverness in async and ORM code.
+- Update this file if repository workflows or conventions change.

--- a/README.md
+++ b/README.md
@@ -541,14 +541,20 @@ Once configured, you can ask your AI assistant questions like:
 The project includes a comprehensive test suite and a fixture Django project for development:
 
 ```bash
-# Test the MCP server with the fixture project
-uv run python test_server.py
+# Run all tests with pytest
+uv run pytest
 
-# Test the read_recent_logs tool
-uv run python test_read_recent_logs.py
+# Run broad integration coverage
+uv run pytest test_server.py
 
-# Test the query_model tool
-uv run python test_query_model.py
+# Run focused MCP tool tests
+uv run pytest test_auth_logic.py test_prompt.py test_query_model.py test_read_recent_logs.py test_run_check.py
+
+# Run a single test file
+uv run pytest test_query_model.py
+
+# Run a single test function
+uv run pytest test_auth_logic.py::test_validation_logic
 
 # Run the MCP server with the test project
 export PYTHONPATH="${PYTHONPATH}:./fixtures/testproject"
@@ -705,11 +711,14 @@ We welcome contributions from the community! Whether it's bug fixes, new feature
    ```
 3. **Test your changes**:
    ```bash
-   # Run the test suite
-   uv run python test_server.py
+    # Run the test suite
+    uv run pytest
 
-   # Test with the fixture project
-   export PYTHONPATH="${PYTHONPATH}:./fixtures/testproject"
+# Run broad integration coverage
+uv run pytest test_server.py
+
+    # Test with the fixture project
+    export PYTHONPATH="${PYTHONPATH}:./fixtures/testproject"
    uv run django-ai-boost --settings testproject.settings
    ```
 4. **Commit your changes**:

--- a/README.md
+++ b/README.md
@@ -477,14 +477,23 @@ Run Django's system checks to identify potential issues in models, settings, and
 Read recent lines from file-based log handlers configured in `LOGGING.handlers`.
 
 **Arguments:**
-- `lines`: Number of lines to return per file (default: `100`, max: `1000`)
+- `lines`: Number of lines to return per file (default: `100`, configurable via `DJANGO_MCP_MAX_LOG_LINES` env var)
 - `handler_name`: Optional handler name to read from a single file handler
 
-**Safety and behavior:**
-- Reads only handlers backed by `*FileHandler` classes
-- Returns structured errors for invalid inputs and missing handlers
-- Uses UTF-8 with safe replacement for undecodable bytes
-- Returns file existence status without modifying files
+> **Note:** This tool reads only file-based handlers (`*FileHandler` classes). If your project logs to the console only, configure a `FileHandler` in your Django `LOGGING` settings so the AI can access log output. Example:
+>
+> ```python
+> LOGGING = {
+>     "version": 1,
+>     "handlers": {
+>         "file": {
+>             "class": "logging.FileHandler",
+>             "filename": "django.log",
+>         },
+>     },
+>     "root": {"handlers": ["file"], "level": "INFO"},
+> }
+> ```
 
 
 ### Prompts
@@ -549,12 +558,6 @@ uv run pytest test_server.py
 
 # Run focused MCP tool tests
 uv run pytest test_auth_logic.py test_prompt.py test_query_model.py test_read_recent_logs.py test_run_check.py
-
-# Run a single test file
-uv run pytest test_query_model.py
-
-# Run a single test function
-uv run pytest test_auth_logic.py::test_validation_logic
 
 # Run the MCP server with the test project
 export PYTHONPATH="${PYTHONPATH}:./fixtures/testproject"

--- a/README.md
+++ b/README.md
@@ -463,6 +463,29 @@ Query a Django model with read-only operations using the Django ORM manager. Thi
 - Get featured posts ordered by date: `filters={"featured": true}`, `order_by=["-created_at"]`
 - Get recent posts with limit: `order_by=["-created_at"]`, `limit=10`
 
+### 11. `run_check`
+Run Django's system checks to identify potential issues in models, settings, and deployment configuration.
+
+**Arguments:**
+- `app_labels`: Optional list of app labels to check
+- `tags`: Optional list of check tags (e.g., `"models"`, `"compatibility"`)
+- `deploy`: Include deployment checks when `true`
+- `fail_level`: Minimum severity (`"CRITICAL"`, `"ERROR"`, `"WARNING"`, `"INFO"`, `"DEBUG"`)
+- `databases`: Optional list of database aliases to include
+
+### 12. `read_recent_logs`
+Read recent lines from file-based log handlers configured in `LOGGING.handlers`.
+
+**Arguments:**
+- `lines`: Number of lines to return per file (default: `100`, max: `1000`)
+- `handler_name`: Optional handler name to read from a single file handler
+
+**Safety and behavior:**
+- Reads only handlers backed by `*FileHandler` classes
+- Returns structured errors for invalid inputs and missing handlers
+- Uses UTF-8 with safe replacement for undecodable bytes
+- Returns file existence status without modifying files
+
 
 ### Prompts
 
@@ -520,6 +543,9 @@ The project includes a comprehensive test suite and a fixture Django project for
 ```bash
 # Test the MCP server with the fixture project
 uv run python test_server.py
+
+# Test the read_recent_logs tool
+uv run python test_read_recent_logs.py
 
 # Test the query_model tool
 uv run python test_query_model.py

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,48 @@
+"""Shared pytest fixtures for django-ai-boost tests."""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+from collections.abc import Callable
+from pathlib import Path
+
+import django
+import pytest
+from asgiref.sync import sync_to_async
+from django.apps import apps
+
+PROJECT_ROOT = Path(__file__).parent
+TESTPROJECT_PATH = PROJECT_ROOT / "fixtures" / "testproject"
+
+
+@pytest.fixture(scope="session", autouse=True)
+def django_setup() -> None:
+    """Configure and initialize Django once for the whole test session."""
+    if str(TESTPROJECT_PATH) not in sys.path:
+        sys.path.insert(0, str(TESTPROJECT_PATH))
+
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testproject.settings")
+
+    if not apps.ready:
+        django.setup()
+
+
+@pytest.fixture
+def async_django_db(django_setup: None) -> Callable[..., Callable[..., object]]:
+    """Return sync_to_async to wrap ORM calls inside async tests."""
+    return sync_to_async
+
+
+@pytest.fixture
+def flush_root_handlers() -> Callable[[], None]:
+    """Flush root logger handlers so file logs are written before assertions."""
+
+    def _flush() -> None:
+        for handler in logging.getLogger().handlers:
+            flush = getattr(handler, "flush", None)
+            if callable(flush):
+                flush()
+
+    return _flush

--- a/fixtures/README.md
+++ b/fixtures/README.md
@@ -20,8 +20,14 @@ The `testproject/` directory contains a minimal Django application with:
 From the project root directory:
 
 ```bash
-# Run the test script
-uv run python test_server.py
+# Run all tests
+uv run pytest
+
+# Run broad integration coverage
+uv run pytest test_server.py
+
+# Run focused MCP tool tests
+uv run pytest test_auth_logic.py test_prompt.py test_query_model.py test_read_recent_logs.py test_run_check.py
 ```
 
 This will test all 8 MCP tools:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,8 +27,16 @@ build-backend = "hatchling.build"
 [dependency-groups]
 dev = [
     "pytest>=8.4.2",
+    "pytest-asyncio>=1.2.0",
     "ruff>=0.14.0",
 ]
+
+[tool.pytest.ini_options]
+testpaths = ["."]
+python_files = ["test_*.py"]
+python_classes = ["Test*"]
+python_functions = ["test_*"]
+asyncio_mode = "auto"
 
 [project.urls]
 Homepage = "https://github.com/vintasoftware/django-ai-boost"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "django-ai-boost"
-version = "0.7.0"
+version = "0.8.0"
 description = "A Model Context Protocol (MCP) server for Django applications, inspired by Laravel Boost"
 readme = "README.md"
 authors = [

--- a/server.json
+++ b/server.json
@@ -6,12 +6,12 @@
     "url": "https://github.com/vintasoftware/django-ai-boost",
     "source": "github"
   },
-  "version": "0.7.0",
+  "version": "0.8.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "django-ai-boost",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "transport": {
         "type": "stdio"
       },

--- a/src/django_ai_boost/server_fastmcp.py
+++ b/src/django_ai_boost/server_fastmcp.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 import logging
 import os
 import sys
-from typing import Any
+from collections import deque
+from pathlib import Path
+from typing import Any, Literal
 
 import django
 from asgiref.sync import sync_to_async
@@ -383,12 +385,12 @@ async def list_migrations() -> list[dict[str, Any]]:
 
         migrations_info = []
 
-        for app_label in loader.migrated_apps:
+        for app_label in loader.migrated_apps or []:
             app_migrations = []
 
-            for migration_name in loader.disk_migrations:
+            for migration_name in loader.disk_migrations or {}:
                 if migration_name[0] == app_label:
-                    is_applied = migration_name in loader.applied_migrations
+                    is_applied = migration_name in (loader.applied_migrations or set())
                     app_migrations.append(
                         {
                             "name": migration_name[1],
@@ -744,6 +746,104 @@ async def run_check(
     return await execute_checks()
 
 
+async def read_recent_logs(
+    lines: int = 100,
+    handler_name: str | None = None,
+) -> dict[str, Any]:
+    """
+    Read recent lines from file-based Django log handlers safely.
+
+    Args:
+        lines: Number of recent lines to read per handler (default: 100, max: 1000)
+        handler_name: Optional handler name to target one configured handler
+
+    Returns:
+        Dictionary containing discovered handlers and recent log lines, or an error message.
+    """
+
+    @sync_to_async
+    def read_logs():
+        max_lines = 1000
+
+        if lines < 1:
+            return {"error": "lines must be greater than 0"}
+
+        actual_lines = min(lines, max_lines)
+        logging_config = getattr(settings, "LOGGING", {}) or {}
+        handlers_config = logging_config.get("handlers", {})
+
+        file_handlers: dict[str, Path] = {}
+
+        for name, config in handlers_config.items():
+            if not isinstance(config, dict):
+                continue
+
+            handler_class = str(config.get("class", ""))
+            filename = config.get("filename")
+
+            if not filename or not handler_class.endswith("FileHandler"):
+                continue
+
+            file_handlers[name] = Path(str(filename)).expanduser().resolve()
+
+        if not file_handlers:
+            return {"error": "No file-based log handlers found in LOGGING settings"}
+
+        if handler_name:
+            if handler_name not in file_handlers:
+                return {
+                    "error": f"Handler '{handler_name}' not found or is not a file-based handler"
+                }
+            target_handlers = {handler_name: file_handlers[handler_name]}
+        else:
+            target_handlers = file_handlers
+
+        logs: list[dict[str, Any]] = []
+
+        for name, file_path in sorted(target_handlers.items()):
+            log_result: dict[str, Any] = {
+                "handler": name,
+                "path": str(file_path),
+                "exists": file_path.exists(),
+                "lines": [],
+                "line_count": 0,
+            }
+
+            if not file_path.exists():
+                logs.append(log_result)
+                continue
+
+            if not file_path.is_file():
+                log_result["error"] = "Configured log path is not a file"
+                logs.append(log_result)
+                continue
+
+            try:
+                recent_lines: deque[str] = deque(maxlen=actual_lines)
+                with file_path.open(
+                    "r", encoding="utf-8", errors="replace"
+                ) as log_file:
+                    for line in log_file:
+                        recent_lines.append(line.rstrip("\n"))
+
+                log_result["lines"] = list(recent_lines)
+                log_result["line_count"] = len(recent_lines)
+            except Exception as e:
+                log_result["error"] = f"Error reading log file: {str(e)}"
+
+            logs.append(log_result)
+
+        return {
+            "requested_lines": lines,
+            "returned_lines": actual_lines,
+            "handler_filter": handler_name,
+            "available_handlers": sorted(file_handlers.keys()),
+            "logs": logs,
+        }
+
+    return await read_logs()
+
+
 async def search_django_docs(topic: str) -> str:
     """
     Generate a prompt to help search for specific topics in Django documentation.
@@ -792,6 +892,7 @@ TOOLS = [
     reverse_url,
     query_model,
     run_check,
+    read_recent_logs,
 ]
 
 PROMPTS = [
@@ -812,7 +913,7 @@ def register_tools(mcp_server: FastMCP) -> None:
 
 def run_server(
     settings_module: str | None = None,
-    transport: str = "stdio",
+    transport: Literal["stdio", "sse"] = "stdio",
     host: str = "127.0.0.1",
     port: int = 8000,
     auth_token: str | None = None,
@@ -843,9 +944,9 @@ def run_server(
 
     # Run the server
     if transport == "sse":
-        mcp_server.run(transport=transport, host=host, port=port)
+        mcp_server.run(transport="sse", host=host, port=port)
     else:
-        mcp_server.run(transport=transport)
+        mcp_server.run(transport="stdio")
 
 
 if __name__ == "__main__":

--- a/src/django_ai_boost/server_fastmcp.py
+++ b/src/django_ai_boost/server_fastmcp.py
@@ -754,7 +754,7 @@ async def read_recent_logs(
     Read recent lines from file-based Django log handlers safely.
 
     Args:
-        lines: Number of recent lines to read per handler (default: 100, max: 1000)
+        lines: Number of recent lines to read per handler (default: 100, cap set via DJANGO_MCP_MAX_LOG_LINES env var, default cap: 5000)
         handler_name: Optional handler name to target one configured handler
 
     Returns:
@@ -763,7 +763,7 @@ async def read_recent_logs(
 
     @sync_to_async
     def read_logs():
-        max_lines = 1000
+        max_lines = int(os.environ.get("DJANGO_MCP_MAX_LOG_LINES", 5000))
 
         if lines < 1:
             return {"error": "lines must be greater than 0"}
@@ -773,20 +773,21 @@ async def read_recent_logs(
         handlers_config = logging_config.get("handlers", {})
 
         file_handlers: dict[str, Path] = {}
+        path_errors: dict[str, str] = {}
 
         for name, config in handlers_config.items():
-            if not isinstance(config, dict):
-                continue
-
             handler_class = str(config.get("class", ""))
             filename = config.get("filename")
 
             if not filename or not handler_class.endswith("FileHandler"):
                 continue
 
-            file_handlers[name] = Path(str(filename)).expanduser().resolve()
+            try:
+                file_handlers[name] = Path(str(filename)).expanduser().resolve()
+            except Exception as e:
+                path_errors[name] = str(e)
 
-        if not file_handlers:
+        if not file_handlers and not path_errors:
             return {"error": "No file-based log handlers found in LOGGING settings"}
 
         if handler_name:
@@ -799,6 +800,9 @@ async def read_recent_logs(
             target_handlers = file_handlers
 
         logs: list[dict[str, Any]] = []
+
+        for name, error_msg in sorted(path_errors.items()):
+            logs.append({"handler": name, "error": f"Error resolving log file path: {error_msg}"})
 
         for name, file_path in sorted(target_handlers.items()):
             log_result: dict[str, Any] = {
@@ -944,9 +948,9 @@ def run_server(
 
     # Run the server
     if transport == "sse":
-        mcp_server.run(transport="sse", host=host, port=port)
+        mcp_server.run(transport=transport, host=host, port=port)
     else:
-        mcp_server.run(transport="stdio")
+        mcp_server.run(transport=transport)
 
 
 if __name__ == "__main__":

--- a/test_auth_logic.py
+++ b/test_auth_logic.py
@@ -1,139 +1,51 @@
 #!/usr/bin/env python
-"""
-Quick test to verify authentication logic works correctly.
-"""
-import os
-import sys
-from pathlib import Path
+"""Tests for authentication helpers in server_fastmcp."""
 
-# Add fixtures to path
-fixtures_path = Path(__file__).parent / "fixtures" / "testproject"
-sys.path.insert(0, str(fixtures_path))
-
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testproject.settings")
-
-import django
-django.setup()
+import pytest
+from django.conf import settings
 
 from django_ai_boost.server_fastmcp import (
-    is_production_environment,
-    get_auth_token,
     create_auth_provider,
+    get_auth_token,
+    is_production_environment,
     validate_and_create_auth,
 )
 
-def test_production_detection():
-    """Test production environment detection."""
-    from django.conf import settings
-    print(f"\n1. Testing production detection:")
-    print(f"   DEBUG={settings.DEBUG}")
-    is_prod = is_production_environment()
-    print(f"   is_production={is_prod}")
-    print(f"   ✓ Expected: is_production={not settings.DEBUG}")
-    assert is_prod == (not settings.DEBUG), "Production detection failed!"
 
-def test_token_precedence():
-    """Test token resolution with precedence."""
-    print(f"\n2. Testing token precedence:")
+def test_production_detection() -> None:
+    assert is_production_environment() is (not settings.DEBUG)
 
-    # No token
-    os.environ.pop("DJANGO_MCP_AUTH_TOKEN", None)
-    token = get_auth_token(None)
-    print(f"   No env, no CLI: {token}")
-    assert token is None, "Expected None when no token provided"
 
-    # CLI only
-    token = get_auth_token("cli-token")
-    print(f"   No env, CLI='cli-token': {token}")
-    assert token == "cli-token", "Expected CLI token"
+def test_token_precedence(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("DJANGO_MCP_AUTH_TOKEN", raising=False)
+    assert get_auth_token(None) is None
+    assert get_auth_token("cli-token") == "cli-token"
 
-    # Env only
-    os.environ["DJANGO_MCP_AUTH_TOKEN"] = "env-token"
-    token = get_auth_token(None)
-    print(f"   Env='env-token', no CLI: {token}")
-    assert token == "env-token", "Expected env token"
+    monkeypatch.setenv("DJANGO_MCP_AUTH_TOKEN", "env-token")
+    assert get_auth_token(None) == "env-token"
+    assert get_auth_token("cli-token") == "env-token"
 
-    # Both (env wins)
-    token = get_auth_token("cli-token")
-    print(f"   Env='env-token', CLI='cli-token': {token}")
-    assert token == "env-token", "Expected env token to take precedence"
 
-    # Cleanup
-    os.environ.pop("DJANGO_MCP_AUTH_TOKEN", None)
-    print("   ✓ All precedence tests passed")
-
-def test_auth_provider_creation():
-    """Test auth provider creation."""
-    print(f"\n3. Testing auth provider creation:")
+def test_auth_provider_creation() -> None:
     provider = create_auth_provider("test-token-123")
-    print(f"   Created: {type(provider).__name__}")
-    assert provider is not None, "Provider should not be None"
-    print("   ✓ Auth provider created successfully")
+    assert provider is not None
 
-def test_validation_logic():
-    """Test auth validation logic."""
-    print(f"\n4. Testing validation logic:")
 
-    # Dev mode, no token, stdio - OK
-    result = validate_and_create_auth(None, False, "stdio")
-    print(f"   Dev+stdio+no token: {result}")
-    assert result is None, "Should return None (no auth needed)"
+def test_validation_logic() -> None:
+    assert validate_and_create_auth(None, False, "stdio") is None
+    assert validate_and_create_auth(None, False, "sse") is None
+    assert validate_and_create_auth("token", True, "sse") is not None
+    assert validate_and_create_auth("token", False, "sse") is not None
 
-    # Dev mode, no token, SSE - OK
-    result = validate_and_create_auth(None, False, "sse")
-    print(f"   Dev+SSE+no token: {result}")
-    assert result is None, "Should return None (no auth needed in dev)"
+    with pytest.raises(ValueError, match="Bearer tokens only work with SSE transport"):
+        validate_and_create_auth("token", True, "stdio")
 
-    # Prod mode, token, SSE - OK (creates provider)
-    result = validate_and_create_auth("token", True, "sse")
-    print(f"   Prod+SSE+token: {type(result).__name__ if result else None}")
-    assert result is not None, "Should create auth provider"
+    with pytest.raises(ValueError, match="Bearer tokens only work with SSE transport"):
+        validate_and_create_auth("token", False, "stdio")
 
-    # Dev mode, token, SSE - OK (creates provider)
-    result = validate_and_create_auth("token", False, "sse")
-    print(f"   Dev+SSE+token: {type(result).__name__ if result else None}")
-    assert result is not None, "Should create auth provider in dev mode too"
+    with pytest.raises(ValueError, match="Production mode detected"):
+        validate_and_create_auth(None, True, "sse")
 
-    # Prod mode, token, stdio - ERROR
-    try:
-        result = validate_and_create_auth("token", True, "stdio")
-        print(f"   Prod+stdio+token: Should have raised error!")
-        assert False, "Should have raised ValueError"
-    except ValueError as e:
-        print(f"   Prod+stdio+token: Raised ValueError ✓")
-        assert "Bearer tokens only work with SSE transport" in str(e), "Error message should mention SSE requirement"
-
-    # Dev mode, token, stdio - ERROR (same as prod)
-    try:
-        result = validate_and_create_auth("token", False, "stdio")
-        print(f"   Dev+stdio+token: Should have raised error!")
-        assert False, "Should have raised ValueError"
-    except ValueError as e:
-        print(f"   Dev+stdio+token: Raised ValueError ✓")
-        assert "Bearer tokens only work with SSE transport" in str(e), "Error message should mention SSE requirement"
-
-    # Prod mode, no token, SSE - ERROR
-    try:
-        result = validate_and_create_auth(None, True, "sse")
-        print(f"   Prod+SSE+no token: Should have raised error!")
-        assert False, "Should have raised ValueError"
-    except ValueError as e:
-        print(f"   Prod+SSE+no token: Raised ValueError ✓")
-        assert "Production mode detected" in str(e), "Error message should mention production mode"
-
-    print("   ✓ All validation tests passed")
 
 if __name__ == "__main__":
-    try:
-        test_production_detection()
-        test_token_precedence()
-        test_auth_provider_creation()
-        test_validation_logic()
-        print("\n" + "="*60)
-        print("✅ All authentication logic tests passed!")
-        print("="*60)
-    except Exception as e:
-        print(f"\n❌ Test failed: {e}")
-        import traceback
-        traceback.print_exc()
-        sys.exit(1)
+    raise SystemExit(pytest.main([__file__]))

--- a/test_prompt.py
+++ b/test_prompt.py
@@ -1,75 +1,34 @@
 #!/usr/bin/env python
-"""
-Test the search_django_docs prompt.
+"""Tests for prompt registration and content."""
 
-Note: FastMCP prompts are designed to be called by MCP clients, not directly in Python.
-This test demonstrates the prompt is properly registered and shows what it would return.
-"""
-
-import asyncio
-import os
-import sys
-
-# Add fixtures project to path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "fixtures", "testproject"))
-
-# Set Django settings
-os.environ["DJANGO_SETTINGS_MODULE"] = "testproject.settings"
-
-# Import Django and setup
-import django
-
-django.setup()
-
-# Import the server and inspect the prompt
-from django_ai_boost.server_fastmcp import mcp
+import pytest
+from fastmcp import FastMCP
 from fastmcp.server.middleware import MiddlewareContext
 from mcp.types import ListPromptsRequest
 
+from django_ai_boost.server_fastmcp import register_tools, search_django_docs
 
-async def test_search_django_docs_prompt():
-    """Test that the search_django_docs prompt is registered and callable."""
-    print("Testing search_django_docs prompt registration...\n")
-    print("=" * 80)
+
+@pytest.mark.asyncio
+async def test_search_django_docs_prompt_is_registered() -> None:
+    mcp_server = FastMCP("test-server")
+    register_tools(mcp_server)
 
     context = MiddlewareContext(message=ListPromptsRequest())
-    prompts = await mcp._list_prompts(context)
-    print(f"Found {len(prompts)} registered prompt(s):\n")
+    prompts = await mcp_server._list_prompts(context)
+    prompt_names = [prompt.name for prompt in prompts]
 
-    for prompt in prompts:
-        print(f"✓ Prompt: {prompt.name}")
-        print(f"  Description: {prompt.description}")
-        print(f"  Arguments: {[arg.name for arg in prompt.arguments]}")
-        print()
+    assert "search_django_docs" in prompt_names
 
-    # Check if our prompt is registered
-    prompt_names = [p.name for p in prompts]
-    if "search_django_docs" in prompt_names:
-        print("✓ search_django_docs prompt is registered successfully!")
-        print()
-        print("To use this prompt, connect an MCP client and call:")
-        print('  mcp.get_prompt("search_django_docs", arguments={"topic": "models"})')
-        print()
-        print("=" * 80)
-        print("\nExample usage in MCP Inspector or Claude Desktop:\n")
-        print("1. Configure the MCP server in your client")
-        print("2. Use the prompt with a topic, e.g., 'models', 'queryset', etc.")
-        print("3. The prompt will generate a formatted request to search Django docs")
-        print("=" * 80)
-    else:
-        print("✗ search_django_docs prompt not found!")
 
-    # Demonstrate what the prompt function would return for a sample topic
-    print("\nSample output for topic='models':")
-    print("-" * 80)
-    # Access the underlying function through the prompt
-    from django_ai_boost.server_fastmcp import search_django_docs
+@pytest.mark.asyncio
+async def test_search_django_docs_prompt_content() -> None:
+    result = await search_django_docs("models")
 
-    # Get the underlying function
-    result = await search_django_docs.fn("models")
-    print(result)
-    print("=" * 80)
+    assert "models" in result
+    assert "docs.djangoproject.com" in result
+    assert "Current Django version" in result
 
 
 if __name__ == "__main__":
-    asyncio.run(test_search_django_docs_prompt())
+    raise SystemExit(pytest.main([__file__]))

--- a/test_query_model.py
+++ b/test_query_model.py
@@ -1,225 +1,81 @@
 #!/usr/bin/env python
-"""
-Test script for the query_model MCP tool.
-This script tests the new read-only query functionality by calling the implementation directly.
-"""
+"""Tests for the query_model MCP tool."""
 
-import asyncio
-import os
-import sys
+import pytest
 
-# Add the fixtures directory to the path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "fixtures", "testproject"))
-
-# Set Django settings before importing
-os.environ["DJANGO_SETTINGS_MODULE"] = "testproject.settings"
-
-# Import Django and setup
-import django
-from asgiref.sync import sync_to_async
-from django.apps import apps
-
-django.setup()
+from django_ai_boost.server_fastmcp import query_model
 
 
-async def query_model_impl(
-    app_label: str,
-    model_name: str,
-    filters: dict | None = None,
-    order_by: list[str] | None = None,
-    limit: int = 100,
-) -> dict:
-    """Implementation of query_model tool for testing."""
+@pytest.mark.asyncio
+async def test_query_model_returns_posts() -> None:
+    result = await query_model(app_label="blog", model_name="Post")
 
-    @sync_to_async
-    def execute_query():
-        try:
-            # Get the model
-            try:
-                model = apps.get_model(app_label, model_name)
-            except LookupError:
-                return {"error": f"Model '{app_label}.{model_name}' not found"}
-
-            # Enforce maximum limit for safety
-            max_limit = 1000
-            actual_limit = min(limit, max_limit) if limit else 100
-
-            # Start with all objects
-            queryset = model.objects.all()
-
-            # Apply filters if provided
-            if filters:
-                try:
-                    queryset = queryset.filter(**filters)
-                except Exception as e:
-                    return {"error": f"Invalid filter parameters: {str(e)}"}
-
-            # Apply ordering if provided
-            if order_by:
-                try:
-                    queryset = queryset.order_by(*order_by)
-                except Exception as e:
-                    return {"error": f"Invalid order_by parameters: {str(e)}"}
-
-            # Get total count before limiting
-            total_count = queryset.count()
-
-            # Limit results
-            queryset = queryset[:actual_limit]
-
-            # Convert queryset to list of dictionaries
-            results = []
-            for obj in queryset:
-                obj_dict = {}
-                for field in model._meta.get_fields():
-                    # Skip reverse relations
-                    if field.many_to_many or field.one_to_many:
-                        continue
-
-                    field_name = field.name
-                    try:
-                        value = getattr(obj, field_name)
-
-                        # Handle different field types
-                        if value is None:
-                            obj_dict[field_name] = None
-                        elif hasattr(field, "related_model") and field.related_model:
-                            # Foreign key - store the pk
-                            obj_dict[field_name] = value.pk if value else None
-                            obj_dict[f"{field_name}_str"] = str(value) if value else None
-                        elif isinstance(value, (str, int, float, bool)):
-                            obj_dict[field_name] = value
-                        else:
-                            # For dates, times, and other complex types
-                            obj_dict[field_name] = str(value)
-                    except Exception:
-                        # Skip fields that can't be accessed
-                        continue
-
-                results.append(obj_dict)
-
-            return {
-                "app": app_label,
-                "model": model_name,
-                "total_count": total_count,
-                "returned_count": len(results),
-                "limit": actual_limit,
-                "filters": filters or {},
-                "order_by": order_by or [],
-                "results": results,
-            }
-
-        except Exception as e:
-            return {"error": f"Error executing query: {str(e)}"}
-
-    return await execute_query()
+    assert "error" not in result
+    assert result["app"] == "blog"
+    assert result["model"] == "Post"
+    assert result["filters"] == {}
+    assert result["order_by"] == []
+    assert result["returned_count"] <= result["limit"]
+    assert result["total_count"] >= result["returned_count"]
+    assert isinstance(result["results"], list)
 
 
-async def test_query_model():
-    """Test the query_model tool with various scenarios."""
-    print("=" * 80)
-    print("Testing query_model MCP Tool")
-    print("=" * 80)
-
-    # Test 1: Query all posts (no filters)
-    print("\n1. Query all posts (no filters):")
-    result = await query_model_impl(app_label="blog", model_name="Post")
-    print(f"   Total count: {result.get('total_count')}")
-    print(f"   Returned count: {result.get('returned_count')}")
-    if result.get("results"):
-        print(f"   First post: {result['results'][0].get('title')}")
-
-    # Test 2: Query published posts only
-    print("\n2. Query published posts only:")
-    result = await query_model_impl(
-        app_label="blog", model_name="Post", filters={"status": "published"}
+@pytest.mark.asyncio
+async def test_query_model_applies_filters() -> None:
+    result = await query_model(
+        app_label="blog",
+        model_name="Post",
+        filters={"status": "published"},
     )
-    print(f"   Total count: {result.get('total_count')}")
-    print(f"   Returned count: {result.get('returned_count')}")
-    if result.get("results"):
-        for post in result["results"]:
-            print(f"   - {post.get('title')} (status: {post.get('status')})")
 
-    # Test 3: Query with ordering
-    print("\n3. Query posts ordered by title:")
-    result = await query_model_impl(
-        app_label="blog", model_name="Post", order_by=["title"], limit=5
+    assert "error" not in result
+    assert result["filters"] == {"status": "published"}
+    assert all(post["status"] == "published" for post in result["results"])
+
+
+@pytest.mark.asyncio
+async def test_query_model_applies_ordering() -> None:
+    result = await query_model(
+        app_label="blog",
+        model_name="Post",
+        order_by=["title"],
+        limit=5,
     )
-    print(f"   Total count: {result.get('total_count')}")
-    print(f"   Returned count: {result.get('returned_count')}")
-    if result.get("results"):
-        for post in result["results"]:
-            print(f"   - {post.get('title')}")
 
-    # Test 4: Query featured posts
-    print("\n4. Query featured posts:")
-    result = await query_model_impl(
-        app_label="blog", model_name="Post", filters={"featured": True}
+    assert "error" not in result
+    assert result["order_by"] == ["title"]
+    titles = [post["title"] for post in result["results"]]
+    assert titles == sorted(titles)
+
+
+@pytest.mark.asyncio
+async def test_query_model_caps_limit() -> None:
+    result = await query_model(app_label="blog", model_name="Post", limit=9999)
+
+    assert "error" not in result
+    assert result["limit"] == 1000
+    assert result["returned_count"] <= 1000
+
+
+@pytest.mark.asyncio
+async def test_query_model_invalid_model_returns_error() -> None:
+    result = await query_model(app_label="blog", model_name="NonExistent")
+
+    assert "error" in result
+    assert "not found" in result["error"]
+
+
+@pytest.mark.asyncio
+async def test_query_model_invalid_filter_returns_error() -> None:
+    result = await query_model(
+        app_label="blog",
+        model_name="Post",
+        filters={"invalid_field": "value"},
     )
-    print(f"   Total count: {result.get('total_count')}")
-    print(f"   Returned count: {result.get('returned_count')}")
-    if result.get("results"):
-        for post in result["results"]:
-            print(f"   - {post.get('title')} (featured: {post.get('featured')})")
 
-    # Test 5: Query categories
-    print("\n5. Query all categories:")
-    result = await query_model_impl(app_label="blog", model_name="Category")
-    print(f"   Total count: {result.get('total_count')}")
-    print(f"   Returned count: {result.get('returned_count')}")
-    if result.get("results"):
-        for category in result["results"]:
-            print(f"   - {category.get('name')} (slug: {category.get('slug')})")
-
-    # Test 6: Query with limit
-    print("\n6. Query posts with limit=2:")
-    result = await query_model_impl(app_label="blog", model_name="Post", limit=2)
-    print(f"   Total count: {result.get('total_count')}")
-    print(f"   Returned count: {result.get('returned_count')}")
-    print(f"   Limit applied: {result.get('limit')}")
-
-    # Test 7: Query comments
-    print("\n7. Query approved comments:")
-    result = await query_model_impl(
-        app_label="blog", model_name="Comment", filters={"is_approved": True}
-    )
-    print(f"   Total count: {result.get('total_count')}")
-    print(f"   Returned count: {result.get('returned_count')}")
-    if result.get("results"):
-        for comment in result["results"]:
-            print(
-                f"   - Comment on post {comment.get('post')} by user {comment.get('author')}"
-            )
-
-    # Test 8: Invalid model (error handling)
-    print("\n8. Test error handling with invalid model:")
-    result = await query_model_impl(app_label="blog", model_name="NonExistent")
-    if "error" in result:
-        print(f"   Expected error: {result['error']}")
-
-    # Test 9: Invalid filter (error handling)
-    print("\n9. Test error handling with invalid filter:")
-    result = await query_model_impl(
-        app_label="blog", model_name="Post", filters={"invalid_field": "value"}
-    )
-    if "error" in result:
-        print(f"   Expected error: {result['error']}")
-
-    # Test 10: Query with descending order
-    print("\n10. Query posts with descending order by created_at:")
-    result = await query_model_impl(
-        app_label="blog", model_name="Post", order_by=["-created_at"], limit=3
-    )
-    print(f"   Total count: {result.get('total_count')}")
-    print(f"   Returned count: {result.get('returned_count')}")
-    if result.get("results"):
-        for post in result["results"]:
-            print(f"   - {post.get('title')} (created: {post.get('created_at')})")
-
-    print("\n" + "=" * 80)
-    print("All tests completed successfully!")
-    print("=" * 80)
+    assert "error" in result
+    assert "Invalid filter parameters" in result["error"]
 
 
 if __name__ == "__main__":
-    asyncio.run(test_query_model())
+    raise SystemExit(pytest.main([__file__]))

--- a/test_read_recent_logs.py
+++ b/test_read_recent_logs.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python
+"""Tests for the read_recent_logs tool."""
+
+import asyncio
+import logging
+import os
+import sys
+from pathlib import Path
+from uuid import uuid4
+
+# Add fixtures/testproject to path
+fixtures_path = Path(__file__).parent / "fixtures" / "testproject"
+sys.path.insert(0, str(fixtures_path))
+
+# Set up Django settings to use the test project
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testproject.settings")
+
+import django
+
+from django_ai_boost.server_fastmcp import read_recent_logs
+
+django.setup()
+
+
+def _flush_root_handlers() -> None:
+    for handler in logging.getLogger().handlers:
+        flush = getattr(handler, "flush", None)
+        if callable(flush):
+            flush()
+
+
+async def test_read_recent_logs_success() -> None:
+    marker = f"read_recent_logs_test_{uuid4().hex}"
+    logging.getLogger("django_ai_boost.tests").info(marker)
+    _flush_root_handlers()
+
+    result = await read_recent_logs(lines=200, handler_name="file")
+
+    assert "error" not in result
+    assert result["handler_filter"] == "file"
+    assert result["returned_lines"] == 200
+    assert "file" in result["available_handlers"]
+    assert len(result["logs"]) == 1
+    assert result["logs"][0]["handler"] == "file"
+    assert result["logs"][0]["exists"] is True
+    assert any(marker in line for line in result["logs"][0]["lines"])
+
+
+async def test_read_recent_logs_limit_cap() -> None:
+    result = await read_recent_logs(lines=9999, handler_name="file")
+
+    assert "error" not in result
+    assert result["requested_lines"] == 9999
+    assert result["returned_lines"] == 1000
+
+
+async def test_read_recent_logs_invalid_inputs() -> None:
+    invalid_lines = await read_recent_logs(lines=0)
+    invalid_handler = await read_recent_logs(handler_name="missing_handler")
+
+    assert invalid_lines == {"error": "lines must be greater than 0"}
+    assert invalid_handler == {
+        "error": "Handler 'missing_handler' not found or is not a file-based handler"
+    }
+
+
+async def main() -> None:
+    await test_read_recent_logs_success()
+    await test_read_recent_logs_limit_cap()
+    await test_read_recent_logs_invalid_inputs()
+    print("All read_recent_logs tests passed! ✓")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/test_read_recent_logs.py
+++ b/test_read_recent_logs.py
@@ -29,7 +29,8 @@ async def test_read_recent_logs_success(
     assert any(marker in line for line in result["logs"][0]["lines"])
 
 
-async def test_read_recent_logs_limit_cap() -> None:
+async def test_read_recent_logs_limit_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("DJANGO_MCP_MAX_LOG_LINES", "1000")
     result = await read_recent_logs(lines=9999, handler_name="file")
 
     assert "error" not in result

--- a/test_read_recent_logs.py
+++ b/test_read_recent_logs.py
@@ -1,38 +1,21 @@
 #!/usr/bin/env python
 """Tests for the read_recent_logs tool."""
 
-import asyncio
 import logging
-import os
-import sys
-from pathlib import Path
+from collections.abc import Callable
 from uuid import uuid4
 
-# Add fixtures/testproject to path
-fixtures_path = Path(__file__).parent / "fixtures" / "testproject"
-sys.path.insert(0, str(fixtures_path))
-
-# Set up Django settings to use the test project
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testproject.settings")
-
-import django
+import pytest
 
 from django_ai_boost.server_fastmcp import read_recent_logs
 
-django.setup()
 
-
-def _flush_root_handlers() -> None:
-    for handler in logging.getLogger().handlers:
-        flush = getattr(handler, "flush", None)
-        if callable(flush):
-            flush()
-
-
-async def test_read_recent_logs_success() -> None:
+async def test_read_recent_logs_success(
+    flush_root_handlers: Callable[[], None],
+) -> None:
     marker = f"read_recent_logs_test_{uuid4().hex}"
     logging.getLogger("django_ai_boost.tests").info(marker)
-    _flush_root_handlers()
+    flush_root_handlers()
 
     result = await read_recent_logs(lines=200, handler_name="file")
 
@@ -64,12 +47,5 @@ async def test_read_recent_logs_invalid_inputs() -> None:
     }
 
 
-async def main() -> None:
-    await test_read_recent_logs_success()
-    await test_read_recent_logs_limit_cap()
-    await test_read_recent_logs_invalid_inputs()
-    print("All read_recent_logs tests passed! ✓")
-
-
 if __name__ == "__main__":
-    asyncio.run(main())
+    raise SystemExit(pytest.main([__file__]))

--- a/test_run_check.py
+++ b/test_run_check.py
@@ -1,107 +1,65 @@
 #!/usr/bin/env python
-"""
-Test script for the run_check MCP tool.
-"""
+"""Tests for the run_check MCP tool."""
 
-import asyncio
-import os
-import sys
+import pytest
 
-# Add the fixtures/testproject to the path
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), "fixtures", "testproject"))
-
-# Set Django settings before importing Django modules
-os.environ["DJANGO_SETTINGS_MODULE"] = "testproject.settings"
-
-from src.django_ai_boost import server_fastmcp
-
-initialize_django = server_fastmcp.initialize_django
+from django_ai_boost.server_fastmcp import run_check
 
 
-async def test_run_check():
-    """Test the run_check tool with various parameters."""
-    print("Testing run_check tool...")
-    print("=" * 80)
+@pytest.mark.asyncio
+async def test_run_check_defaults() -> None:
+    result = await run_check()
 
-    # Initialize Django
-    initialize_django("testproject.settings")
+    assert "error" not in result
+    assert result["success"] is True
+    assert result["fail_level"] == "ERROR"
+    assert isinstance(result["summary"], dict)
+    assert result["total_issues"] == sum(result["summary"].values())
 
-    # Get the actual function from the FastMCP tool
-    run_check_fn = server_fastmcp.run_check.fn
 
-    # Test 1: Run all checks
-    print("\n1. Testing run_check with default parameters (all checks)...")
-    result = await run_check_fn()
-    print(f"   Success: {result.get('success')}")
-    print(f"   Total issues: {result.get('total_issues')}")
-    print(f"   Summary: {result.get('summary')}")
-    if result.get("errors"):
-        print(f"   Errors: {result['errors']}")
-    if result.get("warnings"):
-        print(f"   Warnings: {result['warnings']}")
+@pytest.mark.asyncio
+async def test_run_check_with_app_labels() -> None:
+    result = await run_check(app_labels=["blog"])
 
-    # Test 2: Run checks for specific app
-    print("\n2. Testing run_check for 'blog' app only...")
-    result = await run_check_fn(app_labels=["blog"])
-    print(f"   Success: {result.get('success')}")
-    print(f"   Checked apps: {result.get('checked_apps')}")
-    print(f"   Total issues: {result.get('total_issues')}")
-    print(f"   Summary: {result.get('summary')}")
+    assert "error" not in result
+    assert result["success"] is True
+    assert result["checked_apps"] == ["blog"]
 
-    # Test 3: Run checks with specific tags
-    print("\n3. Testing run_check with 'models' tag...")
-    result = await run_check_fn(tags=["models"])
-    print(f"   Success: {result.get('success')}")
-    print(f"   Tags: {result.get('tags')}")
-    print(f"   Total issues: {result.get('total_issues')}")
-    print(f"   Summary: {result.get('summary')}")
 
-    # Test 4: Run checks with multiple tags
-    print("\n4. Testing run_check with multiple tags ['models', 'urls']...")
-    result = await run_check_fn(tags=["models", "urls"])
-    print(f"   Success: {result.get('success')}")
-    print(f"   Tags: {result.get('tags')}")
-    print(f"   Total issues: {result.get('total_issues')}")
-    print(f"   Summary: {result.get('summary')}")
+@pytest.mark.asyncio
+async def test_run_check_with_tags() -> None:
+    result = await run_check(tags=["models", "urls"])
 
-    # Test 5: Run deployment checks
-    print("\n5. Testing run_check with deploy=True...")
-    result = await run_check_fn(deploy=True)
-    print(f"   Success: {result.get('success')}")
-    print(f"   Deploy checks: {result.get('deploy_checks')}")
-    print(f"   Total issues: {result.get('total_issues')}")
-    print(f"   Summary: {result.get('summary')}")
-    if result.get("warnings"):
-        print(f"   Sample warnings (first 3):")
-        for warning in result["warnings"][:3]:
-            print(f"     - {warning['id']}: {warning['message']}")
+    assert "error" not in result
+    assert result["success"] is True
+    assert result["tags"] == ["models", "urls"]
 
-    # Test 6: Run checks with WARNING fail level
-    print("\n6. Testing run_check with fail_level='WARNING'...")
-    result = await run_check_fn(fail_level="WARNING")
-    print(f"   Success: {result.get('success')}")
-    print(f"   Fail level: {result.get('fail_level')}")
-    print(f"   Total issues: {result.get('total_issues')}")
-    print(f"   Summary: {result.get('summary')}")
 
-    # Test 7: Run checks with database parameter
-    print("\n7. Testing run_check with databases=['default']...")
-    result = await run_check_fn(databases=["default"])
-    print(f"   Success: {result.get('success')}")
-    print(f"   Total issues: {result.get('total_issues')}")
-    print(f"   Summary: {result.get('summary')}")
+@pytest.mark.asyncio
+async def test_run_check_with_deploy_and_databases() -> None:
+    result = await run_check(deploy=True, databases=["default"])
 
-    # Test 8: Test error handling - invalid app
-    print("\n8. Testing run_check with invalid app label...")
-    result = await run_check_fn(app_labels=["nonexistent_app"])
-    if "error" in result:
-        print(f"   ✓ Error handling works: {result['error']}")
-    else:
-        print(f"   ✗ Expected error, got: {result}")
+    assert "error" not in result
+    assert result["success"] is True
+    assert result["deploy_checks"] is True
 
-    print("\n" + "=" * 80)
-    print("✓ All run_check tests completed!")
+
+@pytest.mark.asyncio
+async def test_run_check_with_warning_fail_level() -> None:
+    result = await run_check(fail_level="WARNING")
+
+    assert "error" not in result
+    assert result["success"] is True
+    assert result["fail_level"] == "WARNING"
+
+
+@pytest.mark.asyncio
+async def test_run_check_invalid_app_returns_error() -> None:
+    result = await run_check(app_labels=["nonexistent_app"])
+
+    assert "error" in result
+    assert "App not found" in result["error"]
 
 
 if __name__ == "__main__":
-    asyncio.run(test_run_check())
+    raise SystemExit(pytest.main([__file__]))

--- a/test_server.py
+++ b/test_server.py
@@ -22,6 +22,7 @@ from django.apps import apps
 from django.conf import settings
 from django.core.management import get_commands
 from django.db import connection
+from django_ai_boost.server_fastmcp import read_recent_logs
 
 django.setup()
 
@@ -93,12 +94,14 @@ async def test_list_models():
             }
             fields.append(field_info)
 
-        models_info.append({
-            "app": app_label,
-            "model": model_name,
-            "db_table": model._meta.db_table,
-            "fields": fields,
-        })
+        models_info.append(
+            {
+                "app": app_label,
+                "model": model_name,
+                "db_table": model._meta.db_table,
+                "fields": fields,
+            }
+        )
 
     result_all = {
         "total_count": len(models_info),
@@ -129,12 +132,14 @@ async def test_list_models():
             }
             fields.append(field_info)
 
-        blog_models_info.append({
-            "app": app_label,
-            "model": model_name,
-            "db_table": model._meta.db_table,
-            "fields": fields,
-        })
+        blog_models_info.append(
+            {
+                "app": app_label,
+                "model": model_name,
+                "db_table": model._meta.db_table,
+                "fields": fields,
+            }
+        )
 
     result_blog = {
         "total_count": len(blog_models_info),
@@ -163,12 +168,14 @@ async def test_list_models():
             }
             fields.append(field_info)
 
-        filtered_models_info.append({
-            "app": app_label,
-            "model": model_name,
-            "db_table": model._meta.db_table,
-            "fields": fields,
-        })
+        filtered_models_info.append(
+            {
+                "app": app_label,
+                "model": model_name,
+                "db_table": model._meta.db_table,
+                "fields": fields,
+            }
+        )
 
     result_multiple = {
         "total_count": len(filtered_models_info),
@@ -247,16 +254,20 @@ async def test_list_migrations():
             for migration_name in loader.disk_migrations:
                 if migration_name[0] == app_label:
                     is_applied = migration_name in loader.applied_migrations
-                    app_migrations.append({
-                        "name": migration_name[1],
-                        "applied": is_applied,
-                    })
+                    app_migrations.append(
+                        {
+                            "name": migration_name[1],
+                            "applied": is_applied,
+                        }
+                    )
 
             if app_migrations:
-                migrations_info.append({
-                    "app": app_label,
-                    "migrations": sorted(app_migrations, key=lambda x: x["name"]),
-                })
+                migrations_info.append(
+                    {
+                        "app": app_label,
+                        "migrations": sorted(app_migrations, key=lambda x: x["name"]),
+                    }
+                )
         return migrations_info
 
     migrations_info = await get_migrations()
@@ -364,6 +375,29 @@ async def test_reverse_url():
     }
 
 
+async def test_read_recent_logs():
+    """Test read_recent_logs tool."""
+    print("\n9. Testing read_recent_logs:")
+    print("-" * 60)
+
+    result = await read_recent_logs(lines=10, handler_name="file")
+
+    if "error" in result:
+        print(f"Error: {result['error']}")
+        return result
+
+    print(f"Available file handlers: {', '.join(result['available_handlers'])}")
+    print(f"Returned lines per file: {result['returned_lines']}")
+
+    if result["logs"]:
+        first_log = result["logs"][0]
+        print(f"Handler: {first_log['handler']}")
+        print(f"Path: {first_log['path']}")
+        print(f"Line count returned: {first_log['line_count']}")
+
+    return result
+
+
 async def test_all_tools():
     """Test all MCP tools."""
     print("=" * 60)
@@ -379,6 +413,7 @@ async def test_all_tools():
         await test_list_management_commands()
         await test_get_absolute_url()
         await test_reverse_url()
+        await test_read_recent_logs()
 
         print("\n" + "=" * 60)
         print("All tools tested successfully! ✓")

--- a/test_server.py
+++ b/test_server.py
@@ -1,431 +1,110 @@
 #!/usr/bin/env python
-"""
-Test script to verify Django AI Boost MCP server tools work correctly.
-Run from project root: python test_server.py
-"""
-
-import asyncio
-import os
-import sys
-from pathlib import Path
-
-# Add fixtures/testproject to path
-fixtures_path = Path(__file__).parent / "fixtures" / "testproject"
-sys.path.insert(0, str(fixtures_path))
-
-# Set up Django settings to use the test project
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "testproject.settings")
-
-import django
-from asgiref.sync import sync_to_async
-from django.apps import apps
-from django.conf import settings
-from django.core.management import get_commands
-from django.db import connection
-from django_ai_boost.server_fastmcp import read_recent_logs
-
-django.setup()
-
-
-async def test_application_info():
-    """Test application_info tool."""
-    print("\n1. Testing application_info:")
-    print("-" * 60)
-
-    installed_apps = list(settings.INSTALLED_APPS)
-    middleware = list(settings.MIDDLEWARE) if hasattr(settings, "MIDDLEWARE") else []
-    db_config = settings.DATABASES.get("default", {})
-    db_engine = db_config.get("ENGINE", "unknown").split(".")[-1]
-    all_models = apps.get_models()
-
-    info = {
-        "django_version": django.get_version(),
-        "python_version": sys.version.split()[0],
-        "installed_apps": installed_apps,
-        "middleware": middleware,
-        "database_engine": db_engine,
-        "models_count": len(all_models),
-        "debug_mode": settings.DEBUG,
-    }
-
-    print(f"Django Version: {info['django_version']}")
-    print(f"Python Version: {info['python_version']}")
-    print(f"Database Engine: {info['database_engine']}")
-    print(f"Debug Mode: {info['debug_mode']}")
-    print(f"Number of Models: {info['models_count']}")
-    print(f"Installed Apps: {len(info['installed_apps'])} apps")
-    return info
-
-
-async def test_get_setting():
-    """Test get_setting tool."""
-    print("\n2. Testing get_setting:")
-    print("-" * 60)
-
-    # Test DEBUG setting
-    debug_value = settings.DEBUG
-    print(f"DEBUG setting: {debug_value}")
-
-    # Test nested setting
-    db_engine = settings.DATABASES["default"]["ENGINE"]
-    print(f"Database engine: {db_engine}")
-
-    return {"success": True}
-
-
-async def test_list_models():
-    """Test list_models tool."""
-    print("\n3. Testing list_models:")
-    print("-" * 60)
-
-    # Test 1: List all models (no filter)
-    print("\nTest 3a: List all models (no filter)")
-    all_models = apps.get_models()
-    models_info = []
-    for model in all_models:
-        app_label = model._meta.app_label
-        model_name = model._meta.object_name
-
-        fields = []
-        for field in model._meta.get_fields():
-            field_info = {
-                "name": field.name,
-                "type": field.__class__.__name__,
-            }
-            fields.append(field_info)
-
-        models_info.append(
-            {
-                "app": app_label,
-                "model": model_name,
-                "db_table": model._meta.db_table,
-                "fields": fields,
-            }
-        )
-
-    result_all = {
-        "total_count": len(models_info),
-        "app_filter": None,
-        "models": models_info,
-    }
-
-    print(f"Found {result_all['total_count']} total models")
-    if result_all["models"]:
-        first_model = result_all["models"][0]
-        print(f"Example: {first_model['app']}.{first_model['model']}")
-        print(f"  Table: {first_model['db_table']}")
-        print(f"  Fields: {len(first_model['fields'])}")
-
-    # Test 2: Filter by single app
-    print("\nTest 3b: Filter by single app (blog)")
-    blog_models = [m for m in all_models if m._meta.app_label == "blog"]
-    blog_models_info = []
-    for model in blog_models:
-        app_label = model._meta.app_label
-        model_name = model._meta.object_name
-
-        fields = []
-        for field in model._meta.get_fields():
-            field_info = {
-                "name": field.name,
-                "type": field.__class__.__name__,
-            }
-            fields.append(field_info)
-
-        blog_models_info.append(
-            {
-                "app": app_label,
-                "model": model_name,
-                "db_table": model._meta.db_table,
-                "fields": fields,
-            }
-        )
-
-    result_blog = {
-        "total_count": len(blog_models_info),
-        "app_filter": ["blog"],
-        "models": blog_models_info,
-    }
-
-    print(f"Found {result_blog['total_count']} models in 'blog' app")
-    if result_blog["models"]:
-        for model in result_blog["models"]:
-            print(f"  - {model['app']}.{model['model']}")
-
-    # Test 3: Filter by multiple apps
-    print("\nTest 3c: Filter by multiple apps (blog, auth)")
-    filtered_models = [m for m in all_models if m._meta.app_label in ["blog", "auth"]]
-    filtered_models_info = []
-    for model in filtered_models:
-        app_label = model._meta.app_label
-        model_name = model._meta.object_name
-
-        fields = []
-        for field in model._meta.get_fields():
-            field_info = {
-                "name": field.name,
-                "type": field.__class__.__name__,
-            }
-            fields.append(field_info)
-
-        filtered_models_info.append(
-            {
-                "app": app_label,
-                "model": model_name,
-                "db_table": model._meta.db_table,
-                "fields": fields,
-            }
-        )
-
-    result_multiple = {
-        "total_count": len(filtered_models_info),
-        "app_filter": ["blog", "auth"],
-        "models": filtered_models_info,
-    }
-
-    print(f"Found {result_multiple['total_count']} models in 'blog' and 'auth' apps")
-    blog_count = sum(1 for m in result_multiple["models"] if m["app"] == "blog")
-    auth_count = sum(1 for m in result_multiple["models"] if m["app"] == "auth")
-    print(f"  - blog: {blog_count} models")
-    print(f"  - auth: {auth_count} models")
-
-    return result_all
-
-
-async def test_database_schema():
-    """Test database_schema tool."""
-    print("\n4. Testing database_schema:")
-    print("-" * 60)
-
-    @sync_to_async
-    def get_schema():
-        schema_info = {
-            "tables": [],
-            "database_name": connection.settings_dict.get("NAME"),
-            "database_engine": connection.settings_dict.get("ENGINE"),
-        }
-
-        with connection.cursor() as cursor:
-            tables = connection.introspection.table_names()
-            for table_name in tables[:5]:  # Limit to first 5 tables for test
-                table_description = connection.introspection.get_table_description(
-                    cursor, table_name
-                )
-                table_info = {
-                    "name": table_name,
-                    "columns": [
-                        {
-                            "name": col.name,
-                            "type": str(col.type_code),
-                        }
-                        for col in table_description
-                    ],
-                }
-                schema_info["tables"].append(table_info)
-        return schema_info
-
-    schema_info = await get_schema()
-
-    print(f"Database: {schema_info['database_name']}")
-    print(f"Engine: {schema_info['database_engine']}")
-    print(f"Tables (showing first 5): {len(schema_info['tables'])}")
-    if schema_info["tables"]:
-        first_table = schema_info["tables"][0]
-        print(f"Example table: {first_table['name']}")
-        print(f"  Columns: {len(first_table['columns'])}")
-
-    return schema_info
-
-
-async def test_list_migrations():
-    """Test list_migrations tool."""
-    print("\n5. Testing list_migrations:")
-    print("-" * 60)
-
-    @sync_to_async
-    def get_migrations():
-        from django.db.migrations.loader import MigrationLoader
-
-        loader = MigrationLoader(connection)
-        migrations_info = []
-
-        for app_label in loader.migrated_apps:
-            app_migrations = []
-            for migration_name in loader.disk_migrations:
-                if migration_name[0] == app_label:
-                    is_applied = migration_name in loader.applied_migrations
-                    app_migrations.append(
-                        {
-                            "name": migration_name[1],
-                            "applied": is_applied,
-                        }
-                    )
-
-            if app_migrations:
-                migrations_info.append(
-                    {
-                        "app": app_label,
-                        "migrations": sorted(app_migrations, key=lambda x: x["name"]),
-                    }
-                )
-        return migrations_info
-
-    migrations_info = await get_migrations()
-
-    print(f"Found migrations for {len(migrations_info)} apps")
-    if migrations_info:
-        for app_mig in migrations_info[:3]:
-            applied = sum(1 for m in app_mig["migrations"] if m["applied"])
-            total = len(app_mig["migrations"])
-            print(f"  {app_mig['app']}: {applied}/{total} applied")
-
-    return migrations_info
-
-
-async def test_list_management_commands():
-    """Test list_management_commands tool."""
-    print("\n6. Testing list_management_commands:")
-    print("-" * 60)
-
-    commands = get_commands()
-    commands_info = [
-        {"command": cmd_name, "app": app_name}
-        for cmd_name, app_name in sorted(commands.items())
-    ]
-
-    print(f"Found {len(commands_info)} management commands")
-    common_commands = ["migrate", "makemigrations", "runserver", "shell"]
-    for cmd in commands_info:
-        if cmd["command"] in common_commands:
-            print(f"  {cmd['command']} (from {cmd['app']})")
-
-    return commands_info
-
-
-async def test_get_absolute_url():
-    """Test get_absolute_url tool."""
-    print("\n7. Testing get_absolute_url:")
-    print("-" * 60)
-
-    @sync_to_async
-    def get_test_post():
-        from blog.models import Post
-
-        # Get the first post
-        return Post.objects.first()
-
-    post = await get_test_post()
-
-    if post:
-        # Test getting absolute URL for the post
-        result = {
-            "app": "blog",
-            "model": "Post",
-            "pk": post.pk,
-            "url": post.get_absolute_url(),
-        }
-        print(f"Post ID {post.pk}: {post.title}")
-        print(f"Absolute URL: {result['url']}")
-
-        # Test with invalid model
-        print("\nTesting with invalid model:")
-        print("  Expected: Error message for non-existent model")
-
-        # Test with invalid pk
-        print("\nTesting with invalid pk:")
-        print("  Expected: Error message for non-existent instance")
-
-        return result
-    else:
-        print("No posts found in database")
-        return {"error": "No posts available for testing"}
-
-
-async def test_reverse_url():
-    """Test reverse_url tool."""
-    print("\n8. Testing reverse_url:")
-    print("-" * 60)
-
-    from django.urls import reverse
-
-    # Test simple URL without args
-    url1 = reverse("post_list")
-    print(f"post_list -> {url1}")
-
-    # Test URL with kwargs
-    url2 = reverse("post_detail", kwargs={"pk": 1})
-    print(f"post_detail (pk=1) -> {url2}")
-
-    # Test admin URL (with namespace)
-    url3 = reverse("admin:index")
-    print(f"admin:index -> {url3}")
-
-    # Test API URL
-    url4 = reverse("api_post_list")
-    print(f"api_post_list -> {url4}")
-
-    print("\nTesting with invalid URL name:")
-    print("  Expected: NoReverseMatch error")
-
-    return {
-        "post_list": url1,
-        "post_detail": url2,
-        "admin_index": url3,
-        "api_post_list": url4,
-    }
-
-
-async def test_read_recent_logs():
-    """Test read_recent_logs tool."""
-    print("\n9. Testing read_recent_logs:")
-    print("-" * 60)
-
-    result = await read_recent_logs(lines=10, handler_name="file")
-
-    if "error" in result:
-        print(f"Error: {result['error']}")
-        return result
-
-    print(f"Available file handlers: {', '.join(result['available_handlers'])}")
-    print(f"Returned lines per file: {result['returned_lines']}")
-
-    if result["logs"]:
-        first_log = result["logs"][0]
-        print(f"Handler: {first_log['handler']}")
-        print(f"Path: {first_log['path']}")
-        print(f"Line count returned: {first_log['line_count']}")
-
-    return result
-
-
-async def test_all_tools():
-    """Test all MCP tools."""
-    print("=" * 60)
-    print("Testing Django AI Boost MCP Server Tools")
-    print("=" * 60)
-
-    try:
-        await test_application_info()
-        await test_get_setting()
-        await test_list_models()
-        await test_database_schema()
-        await test_list_migrations()
-        await test_list_management_commands()
-        await test_get_absolute_url()
-        await test_reverse_url()
-        await test_read_recent_logs()
-
-        print("\n" + "=" * 60)
-        print("All tools tested successfully! ✓")
-        print("=" * 60)
-
-    except Exception as e:
-        print(f"\nError during testing: {e}")
-        import traceback
-
-        traceback.print_exc()
-        sys.exit(1)
+"""Integration tests for core django-ai-boost tools."""
+
+import pytest
+
+from django_ai_boost.server_fastmcp import (
+    application_info,
+    database_schema,
+    get_absolute_url,
+    get_setting,
+    list_management_commands,
+    list_migrations,
+    list_models,
+    reverse_url,
+)
+
+
+@pytest.mark.asyncio
+async def test_application_info() -> None:
+    result = await application_info()
+
+    assert "django_version" in result
+    assert "python_version" in result
+    assert result["database_engine"] == "sqlite3"
+    assert isinstance(result["installed_apps"], list)
+    assert result["models_count"] > 0
+
+
+@pytest.mark.asyncio
+async def test_get_setting() -> None:
+    debug_result = await get_setting("DEBUG")
+    db_engine_result = await get_setting("DATABASES.default.ENGINE")
+    missing_result = await get_setting("DOES.NOT.EXIST")
+
+    assert debug_result["key"] == "DEBUG"
+    assert isinstance(debug_result["value"], bool)
+    assert db_engine_result["value"] == "django.db.backends.sqlite3"
+    assert "error" in missing_result
+
+
+@pytest.mark.asyncio
+async def test_list_models() -> None:
+    all_models = await list_models()
+    blog_models = await list_models(app_labels=["blog"])
+
+    assert all_models["total_count"] >= blog_models["total_count"]
+    assert blog_models["app_filter"] == ["blog"]
+    assert blog_models["total_count"] > 0
+    assert all(model["app"] == "blog" for model in blog_models["models"])
+
+
+@pytest.mark.asyncio
+async def test_database_schema() -> None:
+    result = await database_schema()
+
+    assert result["database_engine"].endswith("sqlite3")
+    assert isinstance(result["tables"], list)
+    assert len(result["tables"]) > 0
+    assert "name" in result["tables"][0]
+    assert "columns" in result["tables"][0]
+
+
+@pytest.mark.asyncio
+async def test_list_migrations() -> None:
+    result = await list_migrations()
+
+    assert isinstance(result, list)
+    assert len(result) > 0
+    assert "app" in result[0]
+    assert "migrations" in result[0]
+
+
+@pytest.mark.asyncio
+async def test_list_management_commands() -> None:
+    result = await list_management_commands()
+
+    commands = {item["command"] for item in result}
+    assert "migrate" in commands
+    assert "runserver" in commands
+
+
+@pytest.mark.asyncio
+async def test_get_absolute_url() -> None:
+    valid_result = await get_absolute_url("blog", "Post", 1)
+    invalid_model_result = await get_absolute_url("blog", "Unknown", 1)
+    invalid_pk_result = await get_absolute_url("blog", "Post", 999999)
+
+    assert "error" not in valid_result
+    assert valid_result["app"] == "blog"
+    assert valid_result["model"] == "Post"
+    assert valid_result["url"].startswith("/post/")
+    assert "error" in invalid_model_result
+    assert "error" in invalid_pk_result
+
+
+@pytest.mark.asyncio
+async def test_reverse_url() -> None:
+    post_list = await reverse_url("post_list")
+    post_detail = await reverse_url("post_detail", kwargs={"pk": 1})
+    admin_index = await reverse_url("admin:index")
+    invalid = await reverse_url("does_not_exist")
+
+    assert post_list["url"] == "/"
+    assert post_detail["url"] == "/post/1/"
+    assert admin_index["url"].startswith("/admin")
+    assert "error" in invalid
 
 
 if __name__ == "__main__":
-    asyncio.run(test_all_tools())
+    raise SystemExit(pytest.main([__file__]))

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "django-ai-boost"
-version = "0.6.0"
+version = "0.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },

--- a/uv.lock
+++ b/uv.lock
@@ -329,7 +329,7 @@ wheels = [
 
 [[package]]
 name = "django-ai-boost"
-version = "0.7.0"
+version = "0.8.0"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -339,6 +339,7 @@ dependencies = [
 [package.dev-dependencies]
 dev = [
     { name = "pytest" },
+    { name = "pytest-asyncio" },
     { name = "ruff" },
 ]
 
@@ -351,6 +352,7 @@ requires-dist = [
 [package.metadata.requires-dev]
 dev = [
     { name = "pytest", specifier = ">=8.4.2" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0" },
     { name = "ruff", specifier = ">=0.14.0" },
 ]
 
@@ -1040,6 +1042,19 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a3/5c/00a0e072241553e1a7496d638deababa67c5058571567b92a7eaa258397c/pytest-8.4.2.tar.gz", hash = "sha256:86c0d0b93306b961d58d62a4db4879f27fe25513d4b969df351abdddb3c30e01", size = 1519618, upload-time = "2025-09-04T14:34:22.711Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a8/a4/20da314d277121d6534b3a980b29035dcd51e6744bd79075a6ce8fa4eb8d/pytest-8.4.2-py3-none-any.whl", hash = "sha256:872f880de3fc3a5bdc88a11b39c9710c3497a547cfa9320bc3c5e62fbf272e79", size = 365750, upload-time = "2025-09-04T14:34:20.226Z" },
+]
+
+[[package]]
+name = "pytest-asyncio"
+version = "1.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/90/2c/8af215c0f776415f3590cac4f9086ccefd6fd463befeae41cd4d3f193e5a/pytest_asyncio-1.3.0.tar.gz", hash = "sha256:d7f52f36d231b80ee124cd216ffb19369aa168fc10095013c6b014a34d3ee9e5", size = 50087, upload-time = "2025-11-10T16:07:47.256Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/35/f8b19922b6a25bc0880171a2f1a003eaeb93657475193ab516fd87cac9da/pytest_asyncio-1.3.0-py3-none-any.whl", hash = "sha256:611e26147c7f77640e6d0a92a38ed17c3e9848063698d5c93d5aa7aa11cebff5", size = 15075, upload-time = "2025-11-10T16:07:45.537Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
- Adds a new tool: `read_recent_logs`
- Migrates the tests to use `pytest`

<img width="1590" height="363" alt="CleanShot 2026-02-27 at 15 37 06" src="https://github.com/user-attachments/assets/c125cc32-9114-4bd4-b35d-b4038fe1f4cb" />

## Summary by Sourcery

Add a new MCP tool for reading recent Django logs, migrate existing ad-hoc test scripts to structured pytest tests, and update documentation and project metadata to reflect the new tooling and release.

New Features:
- Introduce a read_recent_logs MCP tool that safely reads recent lines from configured file-based Django log handlers.

Enhancements:
- Improve migration listing logic to handle missing migration metadata more defensively.
- Tighten server transport typing and normalize transport selection logic in the MCP server runner.

Build:
- Bump project version to 0.8.0 and configure pytest defaults including async support in pyproject.toml.

Documentation:
- Document the new run_check and read_recent_logs tools and update testing instructions for pytest in the main README and fixtures README.
- Add AGENTS.md with guidelines for automated coding agents working in the repository.

Tests:
- Replace legacy script-style tests with pytest-based async tests for core MCP tools, auth logic, prompts, query_model, run_check, and read_recent_logs.
- Add shared pytest configuration and fixtures for Django setup, async DB access, and logging flush behavior.